### PR TITLE
保存時・復元時のエラーハンドリング、入力時の文字数重複のバリデーションの追加

### DIFF
--- a/todo.js
+++ b/todo.js
@@ -124,24 +124,32 @@ const createCheckBox = () => {
 
 // ToDoリストをローカルストレージに保存
 function saveTodos() {
-  const todos = [];
-  list.querySelectorAll("li").forEach((li) => {
-    const span = li.querySelector("span");
-    const checkBox = li.querySelector('input[type="checkbox"]');
-    todos.push({
-      text: span.textContent,
-      checked: checkBox.checked,
+  try {
+    const todos = [];
+    list.querySelectorAll("li").forEach((li) => {
+      const span = li.querySelector("span");
+      const checkBox = li.querySelector('input[type="checkbox"]');
+      todos.push({
+        text: span.textContent,
+        checked: checkBox.checked,
+      });
     });
-  });
-  localStorage.setItem("todos", JSON.stringify(todos));
+    localStorage.setItem("todos", JSON.stringify(todos));
+  } catch (e) {
+    alert("データの保存に失敗しました: " + e.message);
+  }
 }
 
 // ToDoリストをローカルストレージから復元
 function loadTodos() {
-  const todos = JSON.parse(localStorage.getItem("todos") || "[]");
-  todos.forEach((todo) => {
-    list.appendChild(createTodoItem(todo.text, todo.checked));
-  });
+  try {
+    const todos = JSON.parse(localStorage.getItem("todos") || "[]");
+    todos.forEach((todo) => {
+      list.appendChild(createTodoItem(todo.text, todo.checked));
+    });
+  } catch (e) {
+    alert("データの復元に失敗しました: " + e.message);
+  }
 }
 
 add_button.addEventListener("click", () => {
@@ -150,9 +158,28 @@ add_button.addEventListener("click", () => {
     alert("文字を入力してください");
     return;
   }
-  list.appendChild(createTodoItem(text));
-  input.value = "";
-  saveTodos();
+
+  if (text.length > 50) {
+    alert("50文字以内で入力してください");
+    return;
+  }
+
+  const exists = Array.from(list.children).some((li) => {
+    const span = li.querySelector("span");
+    return span && span.textContent === text;
+  });
+  if (exists) {
+    alert("同じ内容のタスクが既に存在します");
+    return;
+  }
+
+  try {
+    list.appendChild(createTodoItem(text));
+    input.value = "";
+    saveTodos();
+  } catch (e) {
+    alert("タスクの追加に失敗しました: " + e.message);
+  }
 });
 
 // 初期表示時に復元


### PR DESCRIPTION
タスク保存時・復元時に失敗したらエラーを表示、入力時に５０文字以上の禁止、タスクの重複時のバリデーションを追加しました。